### PR TITLE
update bucket acl policy to latest provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,19 +19,19 @@ resource "aws_s3_bucket_acl" "configuration_bucket_acl" {
   acl    = "private"
 }
 
-resource "aws_s3_bucket_object" "logstash_http" {
+resource "aws_s3_object" "logstash_http" {
   bucket = aws_s3_bucket.configuration_bucket.bucket
   key    = "logstash/http.conf"
   source = "${path.module}/files/logstash/http.conf"
 }
 
-resource "aws_s3_bucket_object" "logstash_conf" {
+resource "aws_s3_object" "logstash_conf" {
   bucket = aws_s3_bucket.configuration_bucket.bucket
   key    = "logstash/logstash.conf"
   source = "${path.module}/files/logstash/logstash.conf"
 }
 
-resource "aws_s3_bucket_object" "logstash_pipeline" {
+resource "aws_s3_object" "logstash_pipeline" {
   bucket = aws_s3_bucket.configuration_bucket.bucket
   key    = "logstash/pipelines.yml"
   source = "${path.module}/files/logstash/pipelines.yml"

--- a/main.tf
+++ b/main.tf
@@ -13,8 +13,6 @@ resource "aws_s3_bucket" "configuration_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "configuration_bucket_acl" {
-  depends_on = [aws_s3_bucket_ownership_controls.configuration_bucket]
-
   bucket = aws_s3_bucket.configuration_bucket.id
   acl    = "private"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "configuration_bucket" {
   bucket = "${var.env_name}-devops-tools-configurations"
-  acl    = "private"
 
   tags = merge(
     var.tags,
@@ -13,7 +12,12 @@ resource "aws_s3_bucket" "configuration_bucket" {
   )
 }
 
+resource "aws_s3_bucket_acl" "configuration_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.configuration_bucket]
 
+  bucket = aws_s3_bucket.configuration_bucket.id
+  acl    = "private"
+}
 
 resource "aws_s3_bucket_object" "logstash_http" {
   bucket = aws_s3_bucket.configuration_bucket.bucket


### PR DESCRIPTION
Fix the following:

Warning: Argument is deprecated
│ 
│   with module.devops_tools_bucket.aws_s3_bucket.configuration_bucket,
│   on .terraform/modules/devops_tools_bucket/main.tf line 3, in resource "aws_s3_bucket" "configuration_bucket":
│    3:   acl    = "private"
│ 
│ Use the aws_s3_bucket_acl resource instead
│ 
│ (and 3 more similar warnings elsewhere)